### PR TITLE
Show all available image sizes

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -879,10 +879,12 @@ function gsfcSave(t) {
      * @return array Array of image size options.
      */    
     public static function get_image_size_options() {
-        $sizes = genesis_get_additional_image_sizes();
-        $image_size_opt['thumbnail'] = 'thumbnail ('. get_option( 'thumbnail_size_w' ) . 'x' . get_option( 'thumbnail_size_h' ) . ')';
-		foreach( ( array )$sizes as $name => $size ) 
-			$image_size_opt[ $name ] = esc_html( $name ) . ' (' . $size['width'] . 'x' . $size['height'] . ')';
+    	// Show all available image sizes
+    	$sizes = genesis_get_image_sizes();
+        // $sizes = genesis_get_additional_image_sizes();
+        // $image_size_opt['thumbnail'] = 'thumbnail ('. get_option( 'thumbnail_size_w' ) . 'x' . get_option( 'thumbnail_size_h' ) . ')';
+	foreach( ( array )$sizes as $name => $size ) 
+		$image_size_opt[ $name ] = esc_html( $name ) . ' (' . $size['width'] . 'x' . $size['height'] . ')';
         return $image_size_opt;
     }
     


### PR DESCRIPTION
Changes the plugin function "get_image_size_options()" on line 881 to show all available sizes in the "show featured image" options of the widget.

As it stands, the option shows only the thumbnail size, plus any additional sizes added by the theme. The WordPress standard sizes are excluded. If no additional sizes exist in the theme, the only option presented is the thumbnail.

This creates a problem in applications where larger sizes are required -- i.e., a front page application, where the widget is used in a div that is 100% of the width of the page. Here, a designer might need to use "large" or "medium" sizes. 

My proposed solution is to substitute the "genesis_get_image_sizes()" function for "genesis_get_additional_image_sizes()" used in line 882 of the existing code. Then dispense with line 883, which is now superfluous, since the thumbnail size is included by the "genesis_get_image_sizes()" function. 

For more information, see: 

1. http://genesis.wp-a2z.org/oik_api/genesis_get_image_sizes/
2. http://designsbynickthegeek.com/tutorials/genesis-explained-image-functions